### PR TITLE
Add NoopRole benchmarks

### DIFF
--- a/benchmark/src/main/scala/scroll/benchmarks/NoopBenchmark.scala
+++ b/benchmark/src/main/scala/scroll/benchmarks/NoopBenchmark.scala
@@ -1,0 +1,46 @@
+package scroll.benchmarks
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import scroll.internal.SCROLLDynamic
+
+import scala.util.Random
+
+object NoopBenchmark {
+  @State(Scope.Thread)
+  class Local {
+    var x, y: Int = _
+    var player: SCROLLDynamic = _
+
+    @Param(Array("true", "false"))
+    var cached: Boolean = _
+
+    @Setup(Level.Iteration)
+    def setup(): Unit = {
+      player = new NoopExample(cached).compartment.player
+      x = Random.nextInt()
+      y = Random.nextInt()
+    }
+  }
+}
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class NoopBenchmark extends AbstractBenchmark {
+  import NoopBenchmark.Local
+
+  @Benchmark
+  def basecall_noargs(local: Local): Any = {
+    local.player.noArgs()
+  }
+
+  @Benchmark
+  def basecall_withargs(local: Local): Any = {
+    local.player.referenceArgAndReturn(local.player)
+  }
+
+  @Benchmark
+  def basecall_primitiveargs(local: Local): Any = {
+    local.player.primitiveArgsAndReturn(local.x, local.y)
+  }
+}

--- a/benchmark/src/main/scala/scroll/benchmarks/NoopBenchmark.scala
+++ b/benchmark/src/main/scala/scroll/benchmarks/NoopBenchmark.scala
@@ -37,6 +37,10 @@ class NoopBenchmark extends AbstractBenchmark {
   import NoopBenchmark.Local
 
   @Benchmark
+  def baseline(): Unit = {
+  }
+
+  @Benchmark
   def basecall_noargs(local: Local): Any = {
     local.player.noArgs()
   }

--- a/benchmark/src/main/scala/scroll/benchmarks/NoopBenchmark.scala
+++ b/benchmark/src/main/scala/scroll/benchmarks/NoopBenchmark.scala
@@ -8,6 +8,7 @@ import scroll.internal.SCROLLDynamic
 import scala.util.Random
 
 object NoopBenchmark {
+
   @State(Scope.Thread)
   class Local {
     var x, y: Int = _
@@ -23,10 +24,16 @@ object NoopBenchmark {
       y = Random.nextInt()
     }
   }
+
 }
 
+/** Measures role method dispatch overhead for a single role bound to
+  * a player, where each role method just forwards the method call to
+  * its base.
+  */
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 class NoopBenchmark extends AbstractBenchmark {
+
   import NoopBenchmark.Local
 
   @Benchmark

--- a/benchmark/src/main/scala/scroll/benchmarks/NoopExample.scala
+++ b/benchmark/src/main/scala/scroll/benchmarks/NoopExample.scala
@@ -10,6 +10,8 @@ class NoopExample(cached: Boolean) {
 
     def referenceArgAndReturn(o: AnyRef): AnyRef = o
 
+    /** Primitive argument and return types probably provoke
+      * autoboxing when a role is bound. */
     def primitiveArgsAndReturn(x: Int, y: Int): Int = x + y
   }
 
@@ -20,6 +22,7 @@ class NoopExample(cached: Boolean) {
       new ScalaRoleGraph(checkForCycles = false)
     }
 
+    /** No-op role methods which just forward to the base */
     class NoopRole {
       implicit val dd = Bypassing(_.isInstanceOf[NoopRole])
 

--- a/benchmark/src/main/scala/scroll/benchmarks/NoopExample.scala
+++ b/benchmark/src/main/scala/scroll/benchmarks/NoopExample.scala
@@ -1,0 +1,43 @@
+package scroll.benchmarks
+
+import scroll.internal.support.DispatchQuery._
+import scroll.internal.Compartment
+import scroll.internal.graph.{CachedScalaRoleGraph, ScalaRoleGraph}
+
+class NoopExample(cached: Boolean) {
+  class BaseType {
+    def noArgs(): AnyRef = this
+
+    def referenceArgAndReturn(o: AnyRef): AnyRef = o
+
+    def primitiveArgsAndReturn(x: Int, y: Int): Int = x + y
+  }
+
+  trait NoopCompartment extends Compartment {
+    override val plays = if (cached) {
+      new CachedScalaRoleGraph(checkForCycles = false)
+    } else {
+      new ScalaRoleGraph(checkForCycles = false)
+    }
+
+    class NoopRole {
+      implicit val dd = Bypassing(_.isInstanceOf[NoopRole])
+
+      def noArgs(): AnyRef = {
+        +this noArgs()
+      }
+
+      def referenceArgAndReturn(o: AnyRef): AnyRef = {
+        +this referenceArgAndReturn(o)
+      }
+
+      def primitiveArgsAndReturn(x: Int, y: Int): Int = {
+        +this primitiveArgsAndReturn(x, y)
+      }
+    }
+  }
+
+  val compartment = new NoopCompartment {
+    val player = new BaseType() play new NoopRole()
+  }
+}


### PR DESCRIPTION
Hi Max,
to compare OT/J, RoleVM and SCROLL I have also implemented the synthetic "NoopRole" microbenchmark for SCROLL. Its purpose is to measure the method call overhead in case of only one bound role, where the methods of that bound role just forward the calls to the base.

I have used that `SCROLLDynamic` type trick in order to perform isolated role method calls inside the benchmark harness. It does what it is supposed to do. But maybe there is a cleaner way?

Please also have a look at the corresponding JMH-based benchmarks for the other languages/runtimes:
- OT/J: [NoopTeam](https://github.com/martinmo/otjbench/blob/master/src/main/otj/otjbench/noop/NoopTeam.java) and [NoopCallinBenchmark](https://github.com/martinmo/otjbench/blob/master/src/main/java/otjbench/jmh/NoopCallinBenchmark.java)
- RoleVM: [NoopCompartment](https://github.com/martinmo/rolevm/blob/master/rolevm-examples/src/main/java/rolevm/examples/noop/NoopCompartment.java) and [NoopCompartmentBenchmark](https://github.com/martinmo/rolevm/blob/master/rolevm-bench/src/main/java/rolevm/bench/noop/NoopCompartmentBenchmark.java)

Thanks,
Martin.